### PR TITLE
fix go_to_next_page(); add argparse & random sleep

### DIFF
--- a/pdxscraper.py
+++ b/pdxscraper.py
@@ -74,8 +74,13 @@ class Scraper:
       self.browser.select_form('FormAgcyEmp')
       field = self.browser.form.find_control('__EVENTTARGET')
       field.readonly = False
-      field.value = 'DataGridAgcyEmp$_ctl54$_ctl1'
-      self.browser.form.action = "SMSGoPersonLkp.aspx?LkpBy=LN"
+      # the javascript swaps the '$' for ':'
+      field.value = 'DataGridAgcyEmp:_ctl54:_ctl1'
+      # disable submit buttons. if these are enabled self.browser.submit() uses
+      # them instead, which resets the search.
+      for c in self.browser.form.controls:
+        if c.type == 'submit':
+          c.disabled = True
       self.current_response = self.browser.submit()
       self.process_page()
     except mechanize._mechanize.LinkNotFoundError as error:


### PR DESCRIPTION
This makes three changes:
* A fix to `go_to_next_page()`. The submit buttons for the form needed to be disabled so going to the next page works. Otherwise `self.browser.submit()` uses them instead and resets the search.
* Add `argparse` for providing the query string
* Add a random sleep in between requests. Using `--max_sleep=0` disables this